### PR TITLE
Fix cache cleanup when archive import is used

### DIFF
--- a/crtSignedContainer.sh
+++ b/crtSignedContainer.sh
@@ -843,15 +843,8 @@ fi
 # Cleanup
 #
 if [ $SB_KEEP_CACHE == false ]; then
-    echo "--> $P: Removing cache subdir: $T"
-    rm -rf "$T"
-    T="$(dirname "$T")"
-
-    if rmdir "$T"; then
-        echo "--> $P: Removing cache dir: $T"
-    else
-        echo "--> $P: Not removing cache dir: $T"
-    fi
+    echo "--> $P: Removing cache dir: $TOPDIR"
+    rm -rf "$TOPDIR"
 fi
 
 exit $RC


### PR DESCRIPTION
The automated cache cleanup (SB_KEEP_CACHE=false) is failing when SB_ARCHIVE_IN is used, because the cleanup is failing to account for the extra artifacts from the import (the "import cruft") and so is finding something unexpected when it tries to do a graceful cleanup.