### PR TITLE
Add --validate-ignore-remainder option to print-container

### DIFF
--- a/container.h
+++ b/container.h
@@ -23,6 +23,9 @@
 #include "ccan/endian/endian.h"
 #include "ccan/short_types/short_types.h"
 
+#define min(x, y) ((x) < (y) ? (x) : (y))
+#define max(x, y) ((x) > (y) ? (x) : (y))
+
 #define PASSED 1
 #define FAILED 0
 #define UNATTEMPTED -1


### PR DESCRIPTION
When --validate is requested the default behavior is to use the actual
payload size for calculating the payload hash.  With this option it will
use the payload size from the container header and ignore any additional
bytes following end of payload.  Useful for validataing container files
with padding after the payload.