### PR TITLE
Fix double delete bug when using OpenSSL v1.1 or higher

### DIFF
--- a/print-container.c
+++ b/print-container.c
@@ -454,8 +454,6 @@ static bool verify_signature(const char *moniker, const unsigned char *dgst,
 		die(EX_SOFTWARE, "%s", "Cannot ECDSA_do_verify");
 	}
 
-	BN_free(r_bn);
-	BN_free(s_bn);
 	BN_free(key_bn);
 
 	EC_KEY_free(ec_key);
@@ -463,6 +461,8 @@ static bool verify_signature(const char *moniker, const unsigned char *dgst,
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	ECDSA_SIG_free(ecdsa_sig);
 #else
+	BN_free(r_bn);
+	BN_free(s_bn);
 	free(ecdsa_sig);
 #endif
 	return status;


### PR DESCRIPTION
This commit fixes a problem wherein, in the verify_signature API, if OpenSSL version is 1.1 or higher, the call to ECDSA_SIG_set0 assigns memory ownership of R+S to the ECDSA signature, but then still frees them before calling ECDSA_SIG_free, leading to an application crash.  Now, those frees will be inhibited in that path, and ECDSA_SIG_free will take care of reclaiming the memory instead.

Signed-off-by: Nick Bofferding opensource@bofferding.net