### PR TITLE
Add support for a "security version" to the signed container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+config.h
+create-container
+hashkeys
+Makefile
+print-container
+bin/

--- a/container.h
+++ b/container.h
@@ -103,7 +103,7 @@ typedef struct {
 	be64 code_start_offset;
 	be64 reserved;
 	be32 flags;
-	uint8_t reserved_0;
+	uint8_t security_version;
 	be64 payload_size;
 	sha2_hash_t payload_hash;
 	uint8_t ecid_count;

--- a/create-container.c
+++ b/create-container.c
@@ -413,6 +413,9 @@ int main(int argc, char* argv[])
 
 	memset(container, 0, SECURE_BOOT_HEADERS_SIZE);
 
+	// Set the default values for non-pointer optional args
+	params.security_version = 0;
+
 #ifdef _AIX
 	for (int i = 1; i < argc; i++) {
 		if (!strcmp(*(argv + i), "--help")) {
@@ -488,9 +491,6 @@ int main(int argc, char* argv[])
 #endif
 		if (opt == -1)
 			break;
-
-        // Set the values for optional args
-        params.security_version = 0;
 
 		switch (opt) {
 		case 'h':

--- a/crtSignedContainer.sh
+++ b/crtSignedContainer.sh
@@ -54,6 +54,7 @@ usage () {
     echo "	                        value, or filename containing value, of the HW Keys hash"
     echo "	    --sign-project-config   INI file containing configuration properties (options"
     echo "	                            set here override those set via cmdline or environment)"
+    echo "	-S, --security-version  Integer, sets the security version container field"
     echo ""
     exit 1
 }
@@ -338,6 +339,7 @@ for arg in "$@"; do
     "--label")      set -- "$@" "-L" ;;
     "--sign-project-FW-token")   set -- "$@" "-L" ;;
     "--sign-project-config")   set -- "$@" "-4" ;;
+    "--security-version")   set -- "$@" "-S" ;;
     "--contrHdrOut") set -- "$@" "-5" ;;
     "--archiveIn")  set -- "$@" "-6" ;;
     "--archiveOut") set -- "$@" "-7" ;;
@@ -348,7 +350,7 @@ for arg in "$@"; do
 done
 
 # Process command-line arguments
-while getopts -- ?hdvw:a:b:c:p:q:r:f:F:o:l:i:m:k:s:L:4:5:6:7:89: opt
+while getopts -- ?hdvw:a:b:c:p:q:r:f:F:o:l:i:m:k:s:L:S:4:5:6:7:89: opt
 do
   case "${opt:?}" in
     v) SB_VERBOSE="TRUE";;
@@ -369,6 +371,7 @@ do
     m) SIGN_MODE="$(to_lower "$OPTARG")";;
     s) SB_SCRATCH_DIR="$OPTARG";;
     L) LABEL="$OPTARG";;
+    S) SECURITY_VERSION="$OPTARG";;
     4) PROJECT_INI="$OPTARG";;
     5) SB_CONTR_HDR_OUT="$OPTARG";;
     6) SB_ARCHIVE_IN="$OPTARG";;
@@ -572,6 +575,7 @@ test "$HW_FLAGS" && ADDL_ARGS="$ADDL_ARGS --hw-flags $HW_FLAGS"
 test "$SW_FLAGS" && ADDL_ARGS="$ADDL_ARGS --sw-flags $SW_FLAGS"
 test "$CS_OFFSET" && ADDL_ARGS="$ADDL_ARGS --sw-cs-offset $CS_OFFSET"
 test "$LABEL" && ADDL_ARGS="$ADDL_ARGS --label $LABEL"
+test "$SECURITY_VERSION" && ADDL_ARGS="$ADDL_ARGS --security-version $SECURITY_VERSION"
 test "$SB_CONTR_HDR_OUT" && CONTR_HDR_OUT_OPT="--dumpContrHdr"
 
 test "$SB_VERBOSE" && SF_DEBUG_ARGS=" -v"

--- a/print-container.c
+++ b/print-container.c
@@ -233,7 +233,7 @@ static void display_container(struct parsed_stb_container c)
 	printf("reserved:          %08lx\n", be64_to_cpu(c.sh->reserved));
 	printf("reserved (ASCII):  %.8s\n", (char *) &(c.sh->reserved));
 	printf("flags:             %08x\n", be32_to_cpu(c.sh->flags));
-	printf("reserved_0:        %02x\n", c.sh->reserved_0);
+	printf("security_version:  %02x\n", c.sh->security_version);
 	printf("payload_size:      %08lx (%lu)\n", be64_to_cpu(c.sh->payload_size),
 			be64_to_cpu(c.sh->payload_size));
 	print_bytes((char *) "payload_hash:      ", (uint8_t *) c.sh->payload_hash,


### PR DESCRIPTION
Replaces an existing reserved field (was filled to 0)