### PR TITLE
Add option to provide sf_client the ssh key passphrase through ENV

### DIFF
--- a/crtSignedContainer.sh
+++ b/crtSignedContainer.sh
@@ -60,7 +60,8 @@ usage () {
     echo "	    --sign-project-config   INI file containing configuration properties (options"
     echo "	                            set here override those set via cmdline or environment)"
     echo "	-S, --security-version  Integer, sets the security version container field"
-    echo "  -V, --container-version Container version to generate (1, 2)"
+    echo "	-V, --container-version Container version to generate (1, 2)"
+    echo "	-P  --password          ENV variable containing the sf_client password to pass to sf_client via 'sf_client --password"
     echo ""
     exit 1
 }
@@ -376,12 +377,13 @@ for arg in "$@"; do
     "--verify")     set -- "$@" "-9" ;;
     "--container-version") set -- "$@" "-V" ;;
     "--fw-ecid")    set -- "$@" "-@" ;;
+    "--password")    set -- "$@" "-P" ;;
     *)              set -- "$@" "$arg"
   esac
 done
 
 # Process command-line arguments
-while getopts -- ?hdvw:a:b:c:0:p:q:r:1:f:F:o:l:i:m:k:s:L:S:V:4:5:6:7:89:@: opt
+while getopts -- ?hdvw:a:b:c:0:p:q:r:1:f:F:o:l:i:m:k:s:L:S:P:V:4:5:6:7:89:@: opt
 do
   case "${opt:?}" in
     v) SB_VERBOSE="TRUE";;
@@ -413,6 +415,7 @@ do
     8) SB_VALIDATE="TRUE";;
     9) SB_VERIFY="$OPTARG";;
     V) CONTAINER_VERSION="$OPTARG";;
+    P) SF_PWD_ENV="$OPTARG";;
     h|\?) usage;;
   esac
 done
@@ -627,6 +630,8 @@ test "$SB_VERBOSE" && SF_DEBUG_ARGS=" -v"
 test "$SB_DEBUG" && SF_DEBUG_ARGS="$SF_DEBUG_ARGS -d -stdout"
 test $CONTAINER_VERSION == 2 && DIGEST_ARG="-sha3-512"
 
+test "$SF_PWD_ENV" && SF_COMMON_ARGS="$SF_COMMON_ARGS --password $SF_PWD_ENV"
+
 #
 # Set defaults for signframework project basenames
 #
@@ -778,7 +783,7 @@ then
             then
                 # Output is pubkey in raw format
                 KEYFILE="$KEYFILE_BASE.raw"
-                sf_client $SF_DEBUG_ARGS -project "$SF_GETPUBKEY_PROJECT_BASE" \
+                sf_client $SF_DEBUG_ARGS $SF_COMMON_ARGS -project "$SF_GETPUBKEY_PROJECT_BASE" \
                           -param "-signproject $SF_PROJECT" \
                           -epwd "$SF_EPWD" -comments "Requesting $SF_PROJECT" \
                           -url sftp://$SF_USER@$SF_SERVER -pkey "$SF_SSHKEY" \
@@ -832,7 +837,7 @@ then
             if [ "$KMS" == "signframework" ]
             then
                 KEYFILE="$KEYFILE_BASE.raw"
-                sf_client $SF_DEBUG_ARGS -project "$SF_GETPUBKEY_PROJECT_BASE" \
+                sf_client $SF_DEBUG_ARGS $SF_COMMON_ARGS -project "$SF_GETPUBKEY_PROJECT_BASE" \
                           -param "-signproject $SF_PROJECT" \
                           -epwd "$SF_EPWD" -comments "Requesting $SF_PROJECT" \
                           -url sftp://$SF_USER@$SF_SERVER -pkey "$SF_SSHKEY" \
@@ -1053,7 +1058,7 @@ then
             then
                 # Output is signature in raw format
                 SIGFILE="$SIGFILE_BASE.raw"
-                sf_client $SF_DEBUG_ARGS -project $SF_PROJECT -epwd "$SF_EPWD" \
+                sf_client $SF_DEBUG_ARGS $SF_COMMON_ARGS -project $SF_PROJECT -epwd "$SF_EPWD" \
                           -comments "Requesting sig for $SF_PROJECT" \
                           -url sftp://$SF_USER@$SF_SERVER -pkey "$SF_SSHKEY" \
                           -payload  "$T/prefix_hdr" -o "$T/$SIGFILE"
@@ -1112,7 +1117,7 @@ then
             then
                 # Output is signature in raw format
                 SIGFILE="$SIGFILE_BASE.raw"
-                sf_client $SF_DEBUG_ARGS -project $SF_PROJECT -epwd "$SF_EPWD" \
+                sf_client $SF_DEBUG_ARGS $SF_COMMON_ARGS -project $SF_PROJECT -epwd "$SF_EPWD" \
                           -comments "Requesting sig for $LABEL from $SF_PROJECT" \
                           -url sftp://$SF_USER@$SF_SERVER -pkey "$SF_SSHKEY" \
                           -payload "$T/software_hdr.md.bin" -o "$T/$SIGFILE"


### PR DESCRIPTION
SSH_AGENT is the preferred solution, but it is not always viable on a system. This provides an alternative mechanism to do multiple passphrase verifications while only having to set the passphrase once.