### PR TITLE
Update crtSignedContainer.sh to ignore SB_PROJECT_INI

### DIFF
--- a/crtSignedContainer.sh
+++ b/crtSignedContainer.sh
@@ -475,7 +475,7 @@ then
     test "$SB_PROJECT_INI_TRANS" && PROJECT_INI=$SB_PROJECT_INI_TRANS
 fi
 
-if [ "$PROJECT_INI" ]
+if [ "$PROJECT_INI" ] && [ "$SIGN_MODE" == "production" ]
 then
     signer_userid=""
     signer_sshkey_file=""

--- a/crtSignedContainer.sh
+++ b/crtSignedContainer.sh
@@ -60,6 +60,7 @@ usage () {
     echo "	    --sign-project-config   INI file(s) containing configuration properties. Multiple"
     echo "	                            files should be comma separated \"file1.ini,file2.ini,etc\"."
     echo "	                            Options set here override those set via cmdline or environment"
+    echo "	                            Only valid for production signing mode"
     echo "	-S, --security-version  Integer, sets the security version container field"
     echo "	-V, --container-version Container version to generate (1, 2, 3)"
     echo "	-P  --password          ENV variable containing the sf_client password to pass to sf_client via 'sf_client --password"


### PR DESCRIPTION
For P11 we have the same script doing both dev v1 and production v3 signing.  When doing production signing the SB_PROJECT_INI env variable is set which includes the HW key tarball to use for production.  Unfortunately this means the dev v1 signing tries to inject the v3 HW key tarball which doesn't work.

This change ignores the SB_PROJECT_INI when not doing production signing as that is the only use case for it.