### PR TITLE
Resolve signing issues on AIX with the code-start-offset parameter

### DIFF
--- a/Makefile.aix
+++ b/Makefile.aix
@@ -3,13 +3,13 @@ CXX=xlC
 all: create-container print-container hashkeys
 
 create-container: create-container.c
-	$(CXX) -I. $^ -o $@ -lssl -lcrypto
+	$(CXX) -q64 -I. $^ -o $@ -lssl -lcrypto
 
 print-container: print-container.c
-	$(CXX) -I. $^ -o $@ -lssl -lcrypto
+	$(CXX) -q64 -I. $^ -o $@ -lssl -lcrypto
 
 hashkeys: hashkeys.c
-	$(CXX) -I. $^ -o $@ -lssl -lcrypto
+	$(CXX) -q64 -I. $^ -o $@ -lssl -lcrypto
 
 clean:
 	$(RM) create-container print-container hashkeys

--- a/Makefile.aix.v3
+++ b/Makefile.aix.v3
@@ -3,13 +3,13 @@ CXX=xlC
 all: create-container print-container hashkeys gendilkey gendilsig verifydilsig extractdilkey
 
 create-container: create-container.c
-	$(CXX) -I. $^ -o $@ -lssl -lcrypto
+	$(CXX) -q64 -I. $^ -o $@ -lssl -lcrypto
 
 print-container: print-container.c
-	$(CXX) -DADD_DILITHIUM -I${MLCA_PATH}/include -I${MLCA_PATH}/qsc/crystals -I. $^ -o $@ -lssl -lcrypto ${MLCA_PATH}/build/libmlca.a
+	$(CXX) -q64 -DADD_DILITHIUM -I${MLCA_PATH}/include -I${MLCA_PATH}/qsc/crystals -I. $^ -o $@ -lssl -lcrypto ${MLCA_PATH}/build/libmlca.a
 
 hashkeys: hashkeys.c
-	$(CXX) -I. $^ -o $@ -lssl -lcrypto
+	$(CXX) -q64 -I. $^ -o $@ -lssl -lcrypto
 
 gendilkey: gendilkey.c
 	$(CXX)  -I. -I${MLCA_PATH}/include -I${MLCA_PATH}/qsc/crystals $^ -o $@ ${MLCA_PATH}/build/libmlca.a -lssl -lcrypto

--- a/create-container.c
+++ b/create-container.c
@@ -862,7 +862,7 @@ int main(int argc, char* argv[])
 			if (!isValidHex(params.hw_cs_offset, 4))
 				die(EX_DATAERR, "%s",
 				    "Invalid input for hw-cs-offset, expecting a 4 byte hexadecimal value");
-			uint64_t data;
+			uint64_t data = 0;
 			sscanf(params.hw_cs_offset, "%lx", &data);
 			ph->code_start_offset = cpu_to_be64(data);
 			verbose_msg("hw-cs-offset = %#010lx", data);
@@ -955,7 +955,7 @@ int main(int argc, char* argv[])
 			if (!isValidHex(params.sw_cs_offset, 4))
 				die(EX_DATAERR, "%s",
 				    "Invalid input for sw-cs-offset, expecting a 4 byte hexadecimal value");
-			uint64_t data;
+			uint64_t data = 0;
 			sscanf(params.sw_cs_offset, "%lx", &data);
 			swh->code_start_offset = cpu_to_be64(data);
 			verbose_msg("sw-cs-offset = %#010lx", data);


### PR DESCRIPTION
Because the application wasn't built as a 64b application some fields were not being handled correctly. This caused the parsing of the code-start-offset parameter to populate the field with garbage