### PR TITLE
Add support for hashing with sha512 for container V3

### DIFF
--- a/container.h
+++ b/container.h
@@ -76,6 +76,9 @@ typedef struct {
 #define HASH_ALG_SHA3_512	2
 	uint8_t sig_alg;	/* (1: SHA-512/ECDSA-521) 2: SHA3-512 ECDSA-521/Dilithium r2 8/7
                                                           3: SHA3-512 ECDSA 521/ML-DSA-87 */
+#define SIG_ALG_SHA512_ECDSA         1
+#define SIG_ALG_SHA3_512_ECDSA_DIL   2
+#define SIG_ALG_SHA3_512_ECDSA_MLDSA 3
 }__attribute__((packed)) ROM_version_raw;
 
 typedef struct {

--- a/container.h
+++ b/container.h
@@ -72,13 +72,17 @@ typedef uint8_t mldsa_signature_t[MLDSA_87_SIG_LENGTH];
 typedef struct {
 	be16 version;		/* (1: see versions above) */
 	uint8_t hash_alg;	/* (1: SHA-512 2: SHA3-512) */
+#define HASH_ALG_NONE		0
 #define HASH_ALG_SHA512		1
 #define HASH_ALG_SHA3_512	2
 	uint8_t sig_alg;	/* (1: SHA-512/ECDSA-521) 2: SHA3-512 ECDSA-521/Dilithium r2 8/7
-                                                          3: SHA3-512 ECDSA 521/ML-DSA-87 */
+                                                          3: SHA3-512 ECDSA-521/ML-DSA-87
+                                                          4: SHA-512 ECDSA-521/ML-DSA-87 */
+#define SIG_ALG_NONE                 0
 #define SIG_ALG_SHA512_ECDSA         1
 #define SIG_ALG_SHA3_512_ECDSA_DIL   2
 #define SIG_ALG_SHA3_512_ECDSA_MLDSA 3
+#define SIG_ALG_SHA512_ECDSA_MLDSA   4
 }__attribute__((packed)) ROM_version_raw;
 
 typedef struct {

--- a/container.h
+++ b/container.h
@@ -72,6 +72,8 @@ typedef uint8_t mldsa_signature_t[MLDSA_87_SIG_LENGTH];
 typedef struct {
 	be16 version;		/* (1: see versions above) */
 	uint8_t hash_alg;	/* (1: SHA-512 2: SHA3-512) */
+#define HASH_ALG_SHA512		1
+#define HASH_ALG_SHA3_512	2
 	uint8_t sig_alg;	/* (1: SHA-512/ECDSA-521) 2: SHA3-512 ECDSA-521/Dilithium r2 8/7
                                                           3: SHA3-512 ECDSA 521/ML-DSA-87 */
 }__attribute__((packed)) ROM_version_raw;

--- a/create-container.c
+++ b/create-container.c
@@ -69,7 +69,7 @@ unsigned char *sha3_512(const unsigned char *data, size_t len, unsigned char *md
 	EVP_MD_CTX_destroy(ctx);
 	return md;
 #else
-    return NULL;
+	return NULL;
 #endif
 }
 
@@ -488,7 +488,7 @@ static struct option const opts[] = {
 	{ "dumpSwHdr",        required_argument, 0,  '2' },
 	{ "security-version", required_argument, 0,  'S' },
 	{ "container-version",required_argument, 0,  'V' },
-    { "fw-ecid",          required_argument, 0,  '3' },
+	{ "fw-ecid",          required_argument, 0,  '3' },
 	{ NULL, 0, NULL, 0 }
 };
 #endif
@@ -716,7 +716,7 @@ int main(int argc, char* argv[])
 		case 'R':
 			params.sw_sigfn_r = optarg;
 			break;
-		  case '}':
+		case '}':
 			params.sw_sigfn_s = optarg;
 			break;
 		case 'l':
@@ -752,34 +752,34 @@ int main(int argc, char* argv[])
 		case '0':
 			params.cthdrfn = optarg;
 			break;
-		  case 'S':
-			  {
-				  int value = atoi(optarg);
-				  if(value < 0 || value >= 256)
-				  {
-					  die(EX_DATAERR, "security-version (%d) must fit into a 1-byte field", value);
-				  }
-				  else
-				  {
-					  params.security_version = (uint8_t)value;
-				  }
-				  break;
-			  }
-		  case 'V':
-			  {
-				  int value = atoi(optarg);
-				  if(value < 0 || value >= 0x10000)
-				  {
-					  die(EX_DATAERR, "container-version (%d) must fit into a 2-byte field", value);
-				  }
-				  else
-				  {
-					  params.container_version = (uint8_t)value;
-				  }
-				  break;
-			  }
-		  default:
-		    usage(EX_USAGE);
+		case 'S':
+			{
+				int value = atoi(optarg);
+				if(value < 0 || value >= 256)
+				{
+					die(EX_DATAERR, "security-version (%d) must fit into a 1-byte field", value);
+				}
+				else
+				{
+					params.security_version = (uint8_t)value;
+				}
+				break;
+			}
+		case 'V':
+			{
+				int value = atoi(optarg);
+				if(value < 0 || value >= 0x10000)
+				{
+					die(EX_DATAERR, "container-version (%d) must fit into a 2-byte field", value);
+				}
+				else
+				{
+					params.container_version = (uint8_t)value;
+				}
+				break;
+			}
+		default:
+			usage(EX_USAGE);
 		}
 	}
 
@@ -807,10 +807,10 @@ int main(int argc, char* argv[])
 		die(EX_NOINPUT, "Invalid container version: %d", params.container_version);
 	}
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-    else if (params.container_version == 2)
-    {
+	else if (params.container_version == 2)
+	{
 		die(EX_NOINPUT, "Invalid container version due to downlevel openssl version : %d", params.container_version);
-    }
+	}
 #endif
 
 	if (!infile)
@@ -1194,7 +1194,7 @@ int main(int argc, char* argv[])
 		swh_v2->payload_size = cpu_to_be64(payload_st.st_size);
 		swh_v2->unprotected_payload_size = 0;
 
-        // Set the FW ECID if provided
+		// Set the FW ECID if provided
 		memset(swh_v2->ecid, 0, ECID_SIZE);
 		if (params.fw_ecid) {
 			if (!isValidHex(params.fw_ecid, ECID_SIZE))
@@ -1204,9 +1204,9 @@ int main(int argc, char* argv[])
 				sscanf(&(params.fw_ecid[x*2]), "%2hhx", &(swh_v2->ecid[x]));
 			}
 			verbose_print((char *) "FW ECID = ", swh_v2->ecid, sizeof(swh_v2->ecid));
-        }
+		}
 
-        memset(swh_v2->reserved2,0, sizeof(swh_v2->reserved2));
+		memset(swh_v2->reserved2,0, sizeof(swh_v2->reserved2));
 
 		// Calculate the payload hash.
 		p = sha3_512(infile, payload_st.st_size, md);

--- a/create-container.c
+++ b/create-container.c
@@ -865,7 +865,7 @@ int main(int argc, char* argv[])
 		ph = container + sizeof(ROM_container_raw);
 		ph->ver_alg.version = cpu_to_be16(1);
 		ph->ver_alg.hash_alg = HASH_ALG_SHA512;
-		ph->ver_alg.sig_alg = 1;
+		ph->ver_alg.sig_alg = SIG_ALG_SHA512_ECDSA;
 
 		// Set code-start-offset.
 		if (params.hw_cs_offset) {
@@ -958,7 +958,7 @@ int main(int argc, char* argv[])
 					    + be64_to_cpu(ph->payload_size));
 		swh->ver_alg.version = cpu_to_be16(1);
 		swh->ver_alg.hash_alg = HASH_ALG_SHA512;
-		swh->ver_alg.sig_alg = 1;
+		swh->ver_alg.sig_alg = SIG_ALG_SHA512_ECDSA;
 
 		// Set code-start-offset.
 		if (params.sw_cs_offset) {
@@ -1099,7 +1099,7 @@ int main(int argc, char* argv[])
 		ph_v2 = (ROM_prefix_header_v2_raw*)&(c_v2->prefix);
 		ph_v2->ver_alg.version = cpu_to_be16(2);
 		ph_v2->ver_alg.hash_alg = HASH_ALG_SHA3_512;
-		ph_v2->ver_alg.sig_alg = 2;
+		ph_v2->ver_alg.sig_alg = SIG_ALG_SHA3_512_ECDSA_DIL;
 		ph_v2->reserved = 0;
 
 		// Set flags.
@@ -1172,7 +1172,7 @@ int main(int argc, char* argv[])
 		swh_v2 = (ROM_sw_header_v2_raw*) &c_v2->swheader;
 		swh_v2->ver_alg.version = cpu_to_be16(2);
 		swh_v2->ver_alg.hash_alg = HASH_ALG_SHA3_512;
-		swh_v2->ver_alg.sig_alg = 2;
+		swh_v2->ver_alg.sig_alg = SIG_ALG_SHA3_512_ECDSA_DIL;
 
 		swh_v2->reserved = 0;
 
@@ -1309,7 +1309,7 @@ int main(int argc, char* argv[])
 		ph_v3 = (ROM_prefix_header_v3_raw*)&(c_v3->prefix);
 		ph_v3->ver_alg.version = cpu_to_be16(3);
 		ph_v3->ver_alg.hash_alg = HASH_ALG_SHA3_512;
-		ph_v3->ver_alg.sig_alg = 3;
+		ph_v3->ver_alg.sig_alg = SIG_ALG_SHA3_512_ECDSA_MLDSA;
 		ph_v3->reserved = 0;
 
 		// Set flags.
@@ -1382,7 +1382,7 @@ int main(int argc, char* argv[])
 		swh_v3 = (ROM_sw_header_v3_raw*) &c_v3->swheader;
 		swh_v3->ver_alg.version = cpu_to_be16(3);
 		swh_v3->ver_alg.hash_alg = HASH_ALG_SHA3_512;
-		swh_v3->ver_alg.sig_alg = 3;
+		swh_v3->ver_alg.sig_alg = SIG_ALG_SHA3_512_ECDSA_MLDSA;
 		swh_v3->reserved = 0;
 
 		// Add component ID (label).

--- a/crtSignedContainer.sh
+++ b/crtSignedContainer.sh
@@ -63,7 +63,8 @@ usage () {
     echo "	                            Only valid for production signing mode"
     echo "	-S, --security-version  Integer, sets the security version container field"
     echo "	-V, --container-version Container version to generate (1, 2, 3)"
-    echo "	-P  --password          ENV variable containing the sf_client password to pass to sf_client via 'sf_client --password"
+    echo "	-P, --password          ENV variable containing the sf_client password to pass to sf_client via 'sf_client --password"
+    echo "	-H, --hash              Hash algorithm to use for container V3: sha3-512 (default), sha512"
     echo ""
     exit 1
 }
@@ -387,13 +388,14 @@ for arg in "$@"; do
     "--verify")     set -- "$@" "-9" ;;
     "--container-version") set -- "$@" "-V" ;;
     "--fw-ecid")    set -- "$@" "-@" ;;
-    "--password")    set -- "$@" "-P" ;;
+    "--password")   set -- "$@" "-P" ;;
+    "--hash")       set -- "$@" "-H" ;;
     *)              set -- "$@" "$arg"
   esac
 done
 
 # Process command-line arguments
-while getopts -- ?hdvw:a:b:c:0:p:q:r:1:f:F:o:l:i:m:k:s:L:S:P:V:4:5:6:7:89:@: opt
+while getopts -- ?hdvw:a:b:c:0:p:q:r:1:f:F:o:l:i:m:k:s:L:S:P:H:V:4:5:6:7:89:@: opt
 do
   case "${opt:?}" in
     v) SB_VERBOSE="TRUE";;
@@ -426,6 +428,7 @@ do
     9) SB_VERIFY="$OPTARG";;
     V) CONTAINER_VERSION="$OPTARG";;
     P) SF_PWD_ENV="$OPTARG";;
+    H) HASHALG="$OPTARG";;
     h|\?) usage;;
   esac
 done
@@ -650,6 +653,11 @@ test "$SB_VERBOSE" && SF_DEBUG_ARGS=" -v"
 test "$SB_DEBUG" && SF_DEBUG_ARGS="$SF_DEBUG_ARGS -d -stdout"
 test $CONTAINER_VERSION == 2 && DIGEST_ARG="-sha3-512"
 test $CONTAINER_VERSION == 3 && DIGEST_ARG="-sha3-512"
+# Container V3 allows choice of hash (sha3-512 or sha512)
+[[ $CONTAINER_VERSION -eq 3 && -n "$HASHALG" ]] && {
+	DIGEST_ARG="-$HASHALG"
+	ADDL_ARGS="$ADDL_ARGS --hash $HASHALG"
+}
 
 test "$SF_PWD_ENV" && SF_COMMON_ARGS="$SF_COMMON_ARGS --password $SF_PWD_ENV"
 

--- a/hashkeys.c
+++ b/hashkeys.c
@@ -51,12 +51,22 @@ int wrap = 100;
 
 void usage(int status);
 
-unsigned char *sha3_512(const unsigned char *data, size_t len, unsigned char *md)
+unsigned char *calc_hash(unsigned hashalg,
+			 const unsigned char *data, size_t len,
+			 unsigned char *md)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	const EVP_MD* alg = EVP_sha3_512();
 	uint32_t md_len = SHA512_DIGEST_LENGTH;
 	EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+	const EVP_MD* alg;
+
+	switch (hashalg) {
+	case HASH_ALG_SHA3_512:
+		alg = EVP_sha3_512();
+		break;
+	default:
+		return NULL;
+	}
 	EVP_DigestInit_ex(ctx, alg, NULL);
 	EVP_DigestUpdate(ctx, data, len);
 	EVP_DigestFinal_ex(ctx, md, &md_len);
@@ -460,9 +470,9 @@ int main(int argc, char* argv[])
 	if (params.container_version == 1) {
 		p = SHA512(c->hw_pkey_a, sizeof(ecc_key_t) * 3, md);
 	} else if (params.container_version == 2) {
-		p = sha3_512(c_v2->hw_pkey_a, sizeof(ecc_key_t) + sizeof(dilithium_key_t), md);
+		p = calc_hash(HASH_ALG_SHA3_512, c_v2->hw_pkey_a, sizeof(ecc_key_t) + sizeof(dilithium_key_t), md);
 	} else if (params.container_version == 3) {
-		p = sha3_512(c_v3->hw_pkey_a, sizeof(ecc_key_t) + sizeof(mldsa_key_t), md);
+		p = calc_hash(HASH_ALG_SHA3_512, c_v3->hw_pkey_a, sizeof(ecc_key_t) + sizeof(mldsa_key_t), md);
 	} else {
 		die(EX_SOFTWARE, "Invalid container version : %d", params.container_version);
 	}

--- a/hashkeys.c
+++ b/hashkeys.c
@@ -63,7 +63,7 @@ unsigned char *sha3_512(const unsigned char *data, size_t len, unsigned char *md
 	EVP_MD_CTX_destroy(ctx);
 	return md;
 #else
-    return NULL;
+	return NULL;
 #endif
 }
 

--- a/print-container.c
+++ b/print-container.c
@@ -1009,7 +1009,7 @@ static bool verify_dilithium_signature(const char *moniker, const unsigned char 
 {
 	bool sRet = false;
 #ifdef ADD_DILITHIUM
-    mlca_ctx_t sCtx;
+	mlca_ctx_t sCtx;
 	MLCA_RC    sMlRc = 0;
 
 	sMlRc = mlca_init(&sCtx,1,0);
@@ -1059,7 +1059,7 @@ static bool verify_mldsa_87_signature(const char *moniker, const unsigned char *
 {
 	bool sRet = false;
 #ifdef ADD_DILITHIUM
-    mlca_ctx_t sCtx;
+	mlca_ctx_t sCtx;
 	MLCA_RC    sMlRc = 0;
 
 	sMlRc = mlca_init(&sCtx,1,0);
@@ -1220,7 +1220,7 @@ static bool getVerificationHash(char *input, unsigned char *md, int len)
 __attribute__((__noreturn__)) static void usage (int status)
 {
 	if (status != 0) {
-			fprintf(stderr, "Try '%s --help' for more information.\n", progname);
+		fprintf(stderr, "Try '%s --help' for more information.\n", progname);
 	}
 	else {
 		printf("Usage: %s [options]\n", progname);

--- a/print-container.c
+++ b/print-container.c
@@ -224,9 +224,9 @@ static void display_version_raw(const ROM_version_raw v)
 	if (v.hash_alg == HASH_ALG_SHA512) printf("  hash_alg: %02x (%s)\n", v.hash_alg, "SHA512");
 	else if (v.hash_alg == HASH_ALG_SHA3_512) printf("  hash_alg: %02x (%s)\n", v.hash_alg, "SHA3-512");
 	else printf("  hash_alg: %02x (%s)\n", v.hash_alg, "UNKNOWN");
-	if (v.sig_alg == 1)	printf("  sig_alg:  %02x (%s)\n", v.sig_alg, "SHA512/ECDSA-521");
-	else if (v.sig_alg == 2) printf("  sig_alg:  %02x (%s)\n", v.sig_alg, "SHA3-512, ECDSA-521/Dilithium r2 8/7");
-	else if (v.sig_alg == 3) printf(" sig_alg:  %02x (%s)\n", v.sig_alg, "SHA3-512, ECDSA 521/ML-DSA-87");
+	if (v.sig_alg == SIG_ALG_SHA512_ECDSA)	printf("  sig_alg:  %02x (%s)\n", v.sig_alg, "SHA512/ECDSA-521");
+	else if (v.sig_alg == SIG_ALG_SHA3_512_ECDSA_DIL) printf("  sig_alg:  %02x (%s)\n", v.sig_alg, "SHA3-512, ECDSA-521/Dilithium r2 8/7");
+	else if (v.sig_alg == SIG_ALG_SHA3_512_ECDSA_MLDSA) printf(" sig_alg:  %02x (%s)\n", v.sig_alg, "SHA3-512, ECDSA 521/ML-DSA-87");
 	else printf("  sig_alg:  %02x (%s)\n", v.sig_alg, "UNKNOWN");
 }
 


### PR DESCRIPTION
To support NIAP's ( National Information Assurance Partnership) requirement of using sha512 for secure boot rather than sha3-512, add sha512 hashing support for container V3 and its related tools such as create-container.c, print-container.c, crtSignedContainer.sh, and hashkeys.c. Keep the default choice always as sha3-512 so that existing users do not need to change anything. Enable the choice of the hash by supporting a --hash option in the tools and calling a function that takes the choice of hash as an input parameter besides the data to hash and the buffer for the resulting digest.
