### PR TITLE
Extend tools for proper ML-DSA pure mode signing

### DIFF
--- a/container.h
+++ b/container.h
@@ -78,7 +78,7 @@ typedef struct {
 	uint8_t sig_alg;	/* (1: SHA-512/ECDSA-521) 2: SHA3-512 ECDSA-521/Dilithium r2 8/7
                                                           3: SHA3-512 ECDSA-521/ML-DSA-87
                                                           4: SHA-512 ECDSA-521/ML-DSA-87
-                                                          5: SHA-512 ECDSA-512/ML-DSA-87 pure mode */
+                                                          5: SHA-512 ECDSA-521/ML-DSA-87 pure mode */
 #define SIG_ALG_NONE                 0
 #define SIG_ALG_SHA512_ECDSA         1
 #define SIG_ALG_SHA3_512_ECDSA_DIL   2

--- a/container.h
+++ b/container.h
@@ -77,12 +77,14 @@ typedef struct {
 #define HASH_ALG_SHA3_512	2
 	uint8_t sig_alg;	/* (1: SHA-512/ECDSA-521) 2: SHA3-512 ECDSA-521/Dilithium r2 8/7
                                                           3: SHA3-512 ECDSA-521/ML-DSA-87
-                                                          4: SHA-512 ECDSA-521/ML-DSA-87 */
+                                                          4: SHA-512 ECDSA-521/ML-DSA-87
+                                                          5: SHA-512 ECDSA-512/ML-DSA-87 pure mode */
 #define SIG_ALG_NONE                 0
 #define SIG_ALG_SHA512_ECDSA         1
 #define SIG_ALG_SHA3_512_ECDSA_DIL   2
 #define SIG_ALG_SHA3_512_ECDSA_MLDSA 3
 #define SIG_ALG_SHA512_ECDSA_MLDSA   4
+#define SIG_ALG_SHA512_ECDSA_MLDSA_PURE_MODE   5
 }__attribute__((packed)) ROM_version_raw;
 
 typedef struct {

--- a/create-container.c
+++ b/create-container.c
@@ -304,7 +304,8 @@ void getSigRaw(ecc_signature_t *sigraw, char *inFile)
 	return;
 }
 
-void writeHdr(void *hdr, const char *outFile, int hdr_type, int container_version, uint8_t hash_alg)
+void writeHdr(void *hdr, const char *outFile, int hdr_type, int container_version, uint8_t hash_alg,
+              int writeRaw)
 {
 	FILE *fp;
 	int r, hdr_sz;
@@ -412,6 +413,21 @@ void writeHdr(void *hdr, const char *outFile, int hdr_type, int container_versio
 		fclose(fp);
 		free(fn);
 	}
+
+	if (writeRaw) {
+		char *fn = malloc(strlen(outFile) + 5);
+
+		// Write the raw data in binary.
+		sprintf(fn, "%s.bin", outFile);
+
+		fp = fopen(fn, "w");
+		if (!fp)
+			die(EX_CANTCREAT, "Cannot create output file: %s: %s", fn,
+					strerror(errno));
+
+		fwrite(hdr, hdr_sz, 1, fp);
+		fclose(fp);
+	}
 	return;
 }
 
@@ -458,6 +474,7 @@ __attribute__((__noreturn__)) void usage (int status)
 			"     --security-version  Integer, sets the security version container field\n"
 			" -V, --container-version Container version to generate (1, 2, 3)\n"
 			" -H, --hash              hash to use for container V3: sha3-512 (default), sha512\n"
+			"     --pure              Write raw data into a file; for ML-DSA pure mode signing\n"
 			"Note:\n"
 			"- Keys A,B,C,P,Q,R must be valid p521 ECC keys. Keys may be provided as public\n"
 			"  or private key in PEM format, or public key in uncompressed raw format.\n"
@@ -504,6 +521,7 @@ static struct option const opts[] = {
 	{ "container-version",required_argument, 0,  'V' },
 	{ "fw-ecid",          required_argument, 0,  '3' },
 	{ "hash",             required_argument, 0,  'H' },
+	{ "pure",             no_argument      , 0,  '4' },
 	{ NULL, 0, NULL, 0 }
 };
 #endif
@@ -538,6 +556,7 @@ static struct {
 	char *cthdrfn;
 	uint8_t security_version;
 	uint8_t container_version;
+	int mldsa_pure_mode;
 } params;
 
 
@@ -653,6 +672,8 @@ int main(int argc, char* argv[])
 			*(argv + i) = "-V";
 		} else if (!strcmp(*(argv + i), "--hash")) {
 			*(argv + i) = "-H";
+		} else if (!strcmp(*(argv + i), "--pure")) {
+			*(argv + i) = "-4";
 		} else if (!strncmp(*(argv + i), "--", 2)) {
 			fprintf(stderr, "%s: unrecognized option \'%s\'\n", progname,
 					*(argv + i));
@@ -664,10 +685,10 @@ int main(int argc, char* argv[])
 	while (1) {
 		int opt;
 #ifdef _AIX
-		opt = getopt(argc, argv, "?hvdw:a:b:c:[:p:q:r:]:A:B:C:{:P:Q:R:}:3:L:I:o:O:f:F:l:0:1:2:3:S:V:H:");
+		opt = getopt(argc, argv, "?hvdw:a:b:c:[:p:q:r:]:A:B:C:{:P:Q:R:}:3:L:I:o:O:f:F:l:0:1:2:3:S:V:H:4");
 #else
 		opt = getopt_long(argc, argv,
-				"hvdw:a:b:c:[:p:q:r:}:A:B:C:{:P:Q:R:}:3:L:I:o:O:f:F:l:0:1:2:3:S:V:H:", opts,
+				"hvdw:a:b:c:[:p:q:r:}:A:B:C:{:P:Q:R:}:3:L:I:o:O:f:F:l:0:1:2:3:S:V:H:4", opts,
 				NULL);
 #endif
 		if (opt == -1)
@@ -807,6 +828,9 @@ int main(int argc, char* argv[])
 					die(EX_DATAERR, "Unsupported hash: %s\n", optarg);
 				break;
 			}
+		case '4':
+			params.mldsa_pure_mode = true;
+			break;
 		default:
 			usage(EX_USAGE);
 		}
@@ -871,10 +895,14 @@ int main(int argc, char* argv[])
 
 		switch (hash_alg) {
 		case HASH_ALG_SHA3_512:
+			if (params.mldsa_pure_mode)
+				die(EX_DATAERR, "%s", "ML-DSA signing in pure mode is only supported when SHA-512 is used\n");
 			sig_alg = SIG_ALG_SHA3_512_ECDSA_MLDSA;
 			break;
 		case HASH_ALG_SHA512:
 			sig_alg = SIG_ALG_SHA512_ECDSA_MLDSA;
+			if (params.mldsa_pure_mode)
+				sig_alg = SIG_ALG_SHA512_ECDSA_MLDSA_PURE_MODE;
 			break;
 		default:
 			die(EX_DATAERR, "Unsupported hash_alg id '%u'\n", hash_alg);
@@ -1005,7 +1033,8 @@ int main(int argc, char* argv[])
 
 		// Dump the Prefix header.
 		if (params.prhdrfn)
-			writeHdr((void *) ph, params.prhdrfn, PREFIX_HDR, params.container_version, HASH_ALG_SHA512);
+			writeHdr((void *) ph, params.prhdrfn, PREFIX_HDR, params.container_version, HASH_ALG_SHA512,
+			         false);
 
 		swh = (ROM_sw_header_raw*) (((uint8_t*) pd) + sizeof(ecc_signature_t) * 3
 					    + be64_to_cpu(ph->payload_size));
@@ -1061,7 +1090,8 @@ int main(int argc, char* argv[])
 
 		// Dump the Software header.
 		if (params.swhdrfn)
-			writeHdr((void *) swh, params.swhdrfn, SOFTWARE_HDR, params.container_version, HASH_ALG_SHA512);
+			writeHdr((void *) swh, params.swhdrfn, SOFTWARE_HDR, params.container_version, HASH_ALG_SHA512,
+			         false);
 
 		ssig = (ROM_sw_sig_raw*) (((uint8_t*) swh) + sizeof(ROM_sw_header_raw));
 		memset(ssig->sw_sig_p, 0, sizeof(ecc_signature_t));
@@ -1087,7 +1117,8 @@ int main(int argc, char* argv[])
 
 		// Dump the full container header.
 		if (params.cthdrfn)
-			writeHdr((void *) c, params.cthdrfn, CONTAINER_HDR, params.container_version, HASH_ALG_SHA512);
+			writeHdr((void *) c, params.cthdrfn, CONTAINER_HDR, params.container_version, HASH_ALG_SHA512,
+			         false);
 
 		// Print container stats.
 		size = (uint8_t*) ph - (uint8_t *) c;
@@ -1220,7 +1251,8 @@ int main(int argc, char* argv[])
 
 		// Dump the Prefix header.
 		if (params.prhdrfn)
-			writeHdr((void *) ph_v2, params.prhdrfn, PREFIX_HDR, params.container_version, HASH_ALG_SHA3_512);
+			writeHdr((void *) ph_v2, params.prhdrfn, PREFIX_HDR, params.container_version, HASH_ALG_SHA3_512,
+			         false);
 
 		swh_v2 = (ROM_sw_header_v2_raw*) &c_v2->swheader;
 		swh_v2->ver_alg.version = cpu_to_be16(2);
@@ -1280,7 +1312,8 @@ int main(int argc, char* argv[])
 
 		// Dump the Software header.
 		if (params.swhdrfn)
-			writeHdr((void *) swh_v2, params.swhdrfn, SOFTWARE_HDR, params.container_version, HASH_ALG_SHA3_512);
+			writeHdr((void *) swh_v2, params.swhdrfn, SOFTWARE_HDR, params.container_version, HASH_ALG_SHA3_512,
+			         false);
 
 		ssig_v2 = (ROM_sw_sig_v2_raw*)&c_v2->sw_data;
 		memset(ssig_v2->sw_sig_p, 0, sizeof(ecc_signature_t));
@@ -1302,7 +1335,8 @@ int main(int argc, char* argv[])
 
 		// Dump the full container header.
 		if (params.cthdrfn)
-			writeHdr((void *) c, params.cthdrfn, CONTAINER_HDR, params.container_version, HASH_ALG_SHA3_512);
+			writeHdr((void *) c, params.cthdrfn, CONTAINER_HDR, params.container_version, HASH_ALG_SHA3_512,
+			         false);
 
 		// Print container stats.
 		size = (uint8_t*) ph_v2 - (uint8_t *) c_v2;
@@ -1430,7 +1464,8 @@ int main(int argc, char* argv[])
 
 		// Dump the Prefix header.
 		if (params.prhdrfn)
-			writeHdr((void *) ph_v3, params.prhdrfn, PREFIX_HDR, params.container_version, hash_alg);
+			writeHdr((void *) ph_v3, params.prhdrfn, PREFIX_HDR, params.container_version, hash_alg,
+			         params.mldsa_pure_mode);
 
 		swh_v3 = (ROM_sw_header_v3_raw*) &c_v3->swheader;
 		swh_v3->ver_alg.version = cpu_to_be16(3);
@@ -1489,7 +1524,8 @@ int main(int argc, char* argv[])
 
 		// Dump the Software header.
 		if (params.swhdrfn)
-			writeHdr((void *) swh_v3, params.swhdrfn, SOFTWARE_HDR, params.container_version, hash_alg);
+			writeHdr((void *) swh_v3, params.swhdrfn, SOFTWARE_HDR, params.container_version, hash_alg,
+			         params.mldsa_pure_mode);
 
 		ssig_v3 = (ROM_sw_sig_v3_raw*)&c_v3->sw_data;
 		memset(ssig_v3->sw_sig_p, 0, sizeof(ecc_signature_t));
@@ -1511,7 +1547,8 @@ int main(int argc, char* argv[])
 
 		// Dump the full container header.
 		if (params.cthdrfn)
-			writeHdr((void *) c, params.cthdrfn, CONTAINER_HDR, params.container_version, hash_alg);
+			writeHdr((void *) c, params.cthdrfn, CONTAINER_HDR, params.container_version, hash_alg,
+			         false);
 
 		// Print container stats.
 		size = (uint8_t*) ph_v3 - (uint8_t *) c_v3;

--- a/create-container.c
+++ b/create-container.c
@@ -427,6 +427,7 @@ void writeHdr(void *hdr, const char *outFile, int hdr_type, int container_versio
 
 		fwrite(hdr, hdr_sz, 1, fp);
 		fclose(fp);
+		free(fn);
 	}
 	return;
 }

--- a/crtSignedContainer.sh
+++ b/crtSignedContainer.sh
@@ -18,6 +18,7 @@ VERIFY_ARGS=""
 DEBUG_ARGS=""
 ADDL_ARGS=""
 DIGEST_ARG="-sha512"
+GENDILSIG_ARGS=""
 
 RC=0
 
@@ -65,6 +66,7 @@ usage () {
     echo "	-V, --container-version Container version to generate (1, 2, 3)"
     echo "	-P, --password          ENV variable containing the sf_client password to pass to sf_client via 'sf_client --password"
     echo "	-H, --hash              Hash algorithm to use for container V3: sha3-512 (default), sha512"
+    echo "	    --pure              Use proper ML-DSA pure mode signing of raw data"
     echo ""
     exit 1
 }
@@ -390,12 +392,13 @@ for arg in "$@"; do
     "--fw-ecid")    set -- "$@" "-@" ;;
     "--password")   set -- "$@" "-P" ;;
     "--hash")       set -- "$@" "-H" ;;
+    "--pure")       set -- "$@" "-2" ;;
     *)              set -- "$@" "$arg"
   esac
 done
 
 # Process command-line arguments
-while getopts -- ?hdvw:a:b:c:0:p:q:r:1:f:F:o:l:i:m:k:s:L:S:P:H:V:4:5:6:7:89:@: opt
+while getopts -- ?hdvw:a:b:c:0:p:q:r:1:f:F:o:l:i:m:k:s:L:S:P:H:V:24:5:6:7:89:@: opt
 do
   case "${opt:?}" in
     v) SB_VERBOSE="TRUE";;
@@ -420,6 +423,7 @@ do
     s) SB_SCRATCH_DIR="$OPTARG";;
     L) LABEL="$OPTARG";;
     S) SECURITY_VERSION="$OPTARG";;
+    2) MLDSA_PURE_MODE="TRUE";;
     4) PROJECT_INI="$OPTARG";;
     5) SB_CONTR_HDR_OUT="$OPTARG";;
     6) SB_ARCHIVE_IN="$OPTARG";;
@@ -648,6 +652,7 @@ test "$SECURITY_VERSION" && ADDL_ARGS="$ADDL_ARGS --security-version $SECURITY_V
 test "$SB_CONTR_HDR_OUT" && CONTR_HDR_OUT_OPT="--dumpContrHdr"
 test "$CONTAINER_VERSION" && ADDL_ARGS="$ADDL_ARGS --container-version $CONTAINER_VERSION"
 test "$FW_ECID" && ADDL_ARGS="$ADDL_ARGS --fw-ecid $FW_ECID"
+test "$MLDSA_PURE_MODE" && GENDILSIG_ARGS="$GENDILSIG_ARGS --pure"
 
 test "$SB_VERBOSE" && SF_DEBUG_ARGS=" -v"
 test "$SB_DEBUG" && SF_DEBUG_ARGS="$SF_DEBUG_ARGS -d -stdout"
@@ -657,6 +662,9 @@ test $CONTAINER_VERSION == 3 && DIGEST_ARG="-sha3-512"
 [[ $CONTAINER_VERSION -eq 3 && -n "$HASHALG" ]] && {
 	DIGEST_ARG="-$HASHALG"
 	ADDL_ARGS="$ADDL_ARGS --hash $HASHALG"
+}
+[[ $CONTAINER_VERSION -eq 3 && -n "$MLDSA_PURE_MODE" ]] && {
+	ADDL_ARGS="$ADDL_ARGS --pure"
 }
 
 test "$SF_PWD_ENV" && SF_COMMON_ARGS="$SF_COMMON_ARGS --password $SF_PWD_ENV"
@@ -991,6 +999,10 @@ then
                 echo "--> $P: Found signature for HW key $(to_upper $KEY).${msg}"
                 cp -p "$SIGFOUND" "$T/"
             else
+                infile="$T/prefix_hdr.md.bin"
+                if [ -n "$MLDSA_PURE_MODE" ]; then
+                    infile="$T/prefix_hdr.bin"
+                fi
                 # If no signature found, try to generate one.
                 if [ -f "$KEYFILE" ] && is_private_key "$KEYFILE"
                 then
@@ -1001,13 +1013,13 @@ then
                 elif [ -f "$KEYFILE" ] && is_dilithium_private_key "$KEYFILE"
                 then
                     echo "--> $P: Generating signature for HW key $(to_upper $KEY)..."
-                    gendilsig -k "$KEYFILE" -i "$T/prefix_hdr.md.bin" -o "$T/$SIGFILE"
+                    gendilsig -k "$KEYFILE" -i "$infile" -o "$T/$SIGFILE" $GENDILSIG_ARGS
                     rc=$?
                     test $rc -ne 0 && die "Call to gendilsig failed with error: $rc"
                 elif [ -f "$KEYFILE" ] && is_dilithium_raw_private_key "$KEYFILE"
                 then
                     echo "--> $P: Generating signature for HW key $(to_upper $KEY)..."
-                    gendilsig -k "$KEYFILE" -i "$T/prefix_hdr.md.bin" -o "$T/$SIGFILE"
+                    gendilsig -k "$KEYFILE" -i "$infile" -o "$T/$SIGFILE" $GENDILSIG_ARGS
                     rc=$?
                     test $rc -ne 0 && die "Call to gendilsig failed with error: $rc"
                 else
@@ -1029,6 +1041,11 @@ then
         test -z "$KEYFILE" && continue
         test "$KEYFILE" == __skip && continue
 
+        infile="$T/software_hdr.md.bin"
+        if [ -n "$MLDSA_PURE_MODE" ]; then
+            infile="$T/software_hdr.bin"
+        fi
+
         # Look for a signature in the local cache dir, if found use it.
         # (but never reuse a sig for SBKT, the payload is always regenerated)
         if [ -f "$T/$SIGFILE" ] && \
@@ -1047,13 +1064,13 @@ then
         elif [ -f "$KEYFILE" ] && is_dilithium_private_key "$KEYFILE"
         then
             echo "--> $P: Generating signature for HW key $(to_upper $KEY)..."
-            gendilsig -k "$KEYFILE" -i "$T/software_hdr.md.bin" -o "$T/$SIGFILE"
+            gendilsig -k "$KEYFILE" -i "$infile" -o "$T/$SIGFILE" $GENDILSIG_ARGS
             rc=$?
             test $rc -ne 0 && die "Call to gendilsig failed with error: $rc"
         elif [ -f "$KEYFILE" ] && is_dilithium_raw_private_key "$KEYFILE"
         then
             echo "--> $P: Generating signature for HW key $(to_upper $KEY)..."
-            gendilsig -k "$KEYFILE" -i "$T/software_hdr.md.bin" -o "$T/$SIGFILE"
+            gendilsig -k "$KEYFILE" -i "$infile" -o "$T/$SIGFILE" $GENDILSIG_ARGS
             rc=$?
             test $rc -ne 0 && die "Call to gendilsig failed with error: $rc"
         else

--- a/dilutils.h
+++ b/dilutils.h
@@ -31,6 +31,7 @@ enum
 };
 
 int readFile(unsigned char* data, size_t* length, const char* filename);
+int readFileAlloc(const char *filename, unsigned char** data, size_t* length);
 int writeFile(const unsigned char* data, size_t length, const char* filename);
 
 int readFile(unsigned char* data, size_t* length, const char* filename)
@@ -105,6 +106,85 @@ int readFile(unsigned char* data, size_t* length, const char* filename)
         if(fclose(sFile))
         {
             printf("**** ERROR: readFile: Failure closing file : %s\n", filename);
+            if(0 == sRc)
+                sRc = 1;
+        }
+    }
+    return sRc;
+}
+
+int readFileAlloc(const char* filename, unsigned char** data, size_t* length)
+{
+    int    sRc    = 0;
+    size_t sBytes = 0;
+    FILE*  sFile  = NULL;
+
+    if(NULL == data || NULL == length || NULL == filename)
+    {
+        printf("**** ERROR : readFileAlloc: Invalid parms\n");
+        sRc = 1;
+    }
+
+    if(0 == sRc)
+    {
+        sFile = fopen(filename, "rb");
+        if(NULL == sFile)
+        {
+            printf("**** ERROR: readFileAlloc: Unable to open file : %s\n", filename);
+            sRc = 1;
+        }
+    }
+
+    /* Allocate memory for file contents */
+    if(0 == sRc)
+    {
+        sRc = fseek(sFile, 0, SEEK_END);
+        if(-1 == sRc)
+        {
+            printf("**** ERROR : readFileAlloc: Unable to find end of : %s\n", filename);
+            sRc = 1;
+        }
+    }
+
+    if(0 == sRc)
+    {
+        long sLen = ftell(sFile);
+        if(-1 == sLen)
+        {
+            printf("**** ERROR : readFileAlloc: Unable to determine length of %s\n", filename);
+            sRc = 1;
+        }
+        else if ((*data = malloc(sLen)) == NULL)
+        {
+            printf(
+                "**** ERROR : readFile: Out of memory for contents of file E:%lu : %s\n",
+                (size_t)sLen,
+                filename);
+            sRc = 1;
+        }
+
+        if (0 == sRc)
+        {
+            *length = (size_t)sLen;
+        }
+    }
+
+    if(0 == sRc)
+    {
+        fseek(sFile, 0, SEEK_SET);
+
+        sBytes = fread(*data, 1, *length, sFile);
+        if(sBytes != *length)
+        {
+            printf("**** ERROR: readFileAlloc: Failure reading from file : %s\n", filename);
+            sRc = 1;
+        }
+    }
+    if(NULL != sFile)
+    {
+        if(fclose(sFile))
+        {
+            printf("**** ERROR: readFileAlloc: Failure closing file : %s\n", filename);
             if(0 == sRc)
                 sRc = 1;
         }

--- a/gendilsig.c
+++ b/gendilsig.c
@@ -88,7 +88,8 @@ int main(int argc, char** argv)
 
     if(sPrintHelp)
     {
-        printf("\ngendilsig -i <input digest> -k <private key> -o <output filename>\n");
+        printf("\ngendilsig -i <input digest or raw data> -k <private key> -o <output filename> [--pure]\n");
+        printf("  --pure   pure mode: -i accepts raw data instead of a digest\n");
         exit(0);
     }
 

--- a/gendilsig.c
+++ b/gendilsig.c
@@ -33,12 +33,12 @@ int main(int argc, char** argv)
 {
     size_t      sPrivKeyBytes     = BUF_SIZE;
     size_t      sWirePrivKeyBytes = BUF_SIZE;
-    size_t      sDigestBytes      = BUF_SIZE;
+    size_t      sTBSBytes         = 0;
     size_t      sSignatureBytes   = BUF_SIZE;
     int         sRc               = 0;
     int         sIdx              = 0;
     const char* sPrivKeyFile      = NULL;
-    const char* sDigestFile       = NULL;
+    const char* sTBSDataFile      = NULL; /* sha512 or sha3-512 digest or plain data */
     const char* sSigFile          = NULL;
     bool        sPrintHelp        = false;
     bool        sVerbose          = false;
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
         else if(strcmp(argv[sIdx], "-i") == 0)
         {
             sIdx++;
-            sDigestFile = argv[sIdx];
+            sTBSDataFile = argv[sIdx];
         }
         else if(strcmp(argv[sIdx], "-k") == 0)
         {
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if(!sPrintHelp && (NULL == sDigestFile || NULL == sPrivKeyFile || NULL == sSigFile))
+    if(!sPrintHelp && (NULL == sTBSDataFile || NULL == sPrivKeyFile || NULL == sSigFile))
     {
         printf("**** ERROR : Missing input parms\n");
         sPrintHelp = true;
@@ -89,21 +89,21 @@ int main(int argc, char** argv)
 
     mlca_ctx_t     sCtx;
     MLCA_RC        sMlRc        = 0;
-    unsigned char* sDigest      = malloc(BUF_SIZE);
+    unsigned char* sTBS         = NULL;
     unsigned char* sSignature   = malloc(BUF_SIZE);
     unsigned char* sPrivKey     = malloc(BUF_SIZE);
     unsigned char* sWirePrivKey = malloc(BUF_SIZE);
 
-    if(!sDigest || !sSignature || !sPrivKey || !sWirePrivKey)
+    if(!sSignature || !sPrivKey || !sWirePrivKey)
     {
         printf("**** ERROR : Allocation Failure\n");
         exit(1);
     }
 
-    sRc = readFile(sDigest, &sDigestBytes, sDigestFile);
-    if(0 == sRc && SHA3_512_DigestSize != sDigestBytes)
+    sRc = readFileAlloc(sTBSDataFile, &sTBS, &sTBSBytes);
+    if(0 == sRc && SHA3_512_DigestSize != sTBSBytes)
     {
-        printf("**** ERROR : %s doesn't appear to be a SHA3-512 digest\n", sDigestFile);
+        printf("**** ERROR : %s doesn't appear to be a SHA3-512 digest\n", sTBSDataFile);
         sRc = 1;
     }
 
@@ -202,8 +202,8 @@ int main(int argc, char** argv)
         printf("Generating %s signature ...\n",gAlgname);
         int gRc = mlca_sign(sSignature,
                             sSignatureBytes, /// validate RC
-                            sDigest,
-                            sDigestBytes,
+                            sTBS,
+                            sTBSBytes,
                             sPrivKey,
                             sPrivKeyBytes,
                             NULL,
@@ -227,7 +227,7 @@ int main(int argc, char** argv)
         writeFile(sSignature, sSignatureBytes, sSigFile);
     }
 
-    free(sDigest);
+    free(sTBS);
     free(sSignature);
     free(sPrivKey);
     free(sWirePrivKey);

--- a/gendilsig.c
+++ b/gendilsig.c
@@ -42,6 +42,7 @@ int main(int argc, char** argv)
     const char* sSigFile          = NULL;
     bool        sPrintHelp        = false;
     bool        sVerbose          = false;
+    bool        sMLDSAPureMode    = false;
 
     for(sIdx = 1; sIdx < argc; sIdx++)
     {
@@ -67,6 +68,10 @@ int main(int argc, char** argv)
         else if(strcmp(argv[sIdx], "-v") == 0)
         {
             sVerbose = true;
+        }
+        else if(strcmp(argv[sIdx], "--pure") == 0)
+        {
+            sMLDSAPureMode = true;
         }
         else
         {
@@ -101,7 +106,8 @@ int main(int argc, char** argv)
     }
 
     sRc = readFileAlloc(sTBSDataFile, &sTBS, &sTBSBytes);
-    if(0 == sRc && SHA3_512_DigestSize != sTBSBytes)
+    /* if pure mode was NOT chosen, then input data must be SHA3-512 or SHA512 */
+    if(0 == sRc && sMLDSAPureMode == false && SHA3_512_DigestSize != sTBSBytes)
     {
         printf("**** ERROR : %s doesn't appear to be a SHA3-512 digest\n", sTBSDataFile);
         sRc = 1;

--- a/gendilsig.c
+++ b/gendilsig.c
@@ -205,7 +205,7 @@ int main(int argc, char** argv)
 
     if(0 == sRc)
     {
-        printf("Generating %s signature ...\n",gAlgname);
+        printf("Generating %s signature ... (signing %zu bytes)\n",gAlgname, sTBSBytes);
         int gRc = mlca_sign(sSignature,
                             sSignatureBytes, /// validate RC
                             sTBS,

--- a/print-container.c
+++ b/print-container.c
@@ -232,6 +232,7 @@ static void display_version_raw(const ROM_version_raw v)
 	else if (v.sig_alg == SIG_ALG_SHA3_512_ECDSA_DIL) printf("  sig_alg:  %02x (%s)\n", v.sig_alg, "SHA3-512, ECDSA-521/Dilithium r2 8/7");
 	else if (v.sig_alg == SIG_ALG_SHA3_512_ECDSA_MLDSA) printf(" sig_alg:  %02x (%s)\n", v.sig_alg, "SHA3-512, ECDSA 521/ML-DSA-87");
 	else if (v.sig_alg == SIG_ALG_SHA512_ECDSA_MLDSA) printf(" sig_alg:  %02x (%s)\n", v.sig_alg, "SHA512, ECDSA 521/ML-DSA-87");
+	else if (v.sig_alg == SIG_ALG_SHA512_ECDSA_MLDSA_PURE_MODE) printf(" sig_alg:  %02x (%s)\n", v.sig_alg, "SHA512, ECDSA 521/ML-DSA-87 pure mode");
 	else printf("  sig_alg:  %02x (%s)\n", v.sig_alg, "UNKNOWN");
 }
 
@@ -761,7 +762,8 @@ static bool validate_container_v2(struct parsed_stb_container_v2 c, int fdin)
 	return status;
 }
 
-static bool validate_container_v3(struct parsed_stb_container_v3 c, int fdin, uint8_t hash_alg)
+static bool validate_container_v3(struct parsed_stb_container_v3 c, int fdin, uint8_t hash_alg,
+                                  int mldsa_pure_mode)
 {
 	static int status = true;
 
@@ -784,8 +786,13 @@ static bool validate_container_v3(struct parsed_stb_container_v3 c, int fdin, ui
 		printf("HW_key_A is NULL, skipping signature check.\n");
 	}
 	if (memcmp(&(c.c->hw_pkey_d), &ECDSA_KEY_NULL, sizeof(ecc_key_t))) {
-		status = verify_mldsa_87_signature("HW_key_D", md, SHA512_DIGEST_LENGTH,
-						    c.pd->hw_sig_d, c.c->hw_pkey_d) && status;
+		if (mldsa_pure_mode)
+			status = verify_mldsa_87_signature("HW_key_D",
+							   c.ph, sizeof(ROM_prefix_header_v3_raw),
+							   c.pd->hw_sig_d, c.c->hw_pkey_d) && status;
+		else
+			status = verify_mldsa_87_signature("HW_key_D", md, SHA512_DIGEST_LENGTH,
+							   c.pd->hw_sig_d, c.c->hw_pkey_d) && status;
 	} else if (verbose) {
 		printf("HW_key_D is NULL, skipping signature check.\n");
 	}
@@ -807,8 +814,13 @@ static bool validate_container_v3(struct parsed_stb_container_v3 c, int fdin, ui
 		printf("%s is NULL, skipping\n", "SW_key_P");
 	}
 	if (memcmp(&(c.pd->sw_pkey_s), &ECDSA_KEY_NULL, sizeof(ecc_key_t))) {
-		status = verify_mldsa_87_signature("SW_key_S", md, SHA512_DIGEST_LENGTH,
-						    c.ssig->sw_sig_s, c.pd->sw_pkey_s) && status;
+		if (mldsa_pure_mode)
+			status = verify_mldsa_87_signature("SW_key_S",
+							   c.sh, sizeof(ROM_sw_header_v3_raw),
+							   c.ssig->sw_sig_s, c.pd->sw_pkey_s) && status;
+		else
+			status = verify_mldsa_87_signature("SW_key_S", md, SHA512_DIGEST_LENGTH,
+							   c.ssig->sw_sig_s, c.pd->sw_pkey_s) && status;
 		sSwKeySize += sizeof(mldsa_key_t);
 	} else if (verbose) {
 		printf("%s is NULL, skipping\n", "SW_key_S");
@@ -1289,6 +1301,7 @@ int main(int argc, char* argv[])
 	int container_status = EX_OK;
 	int validate_status = UNATTEMPTED;
 	int verify_status = UNATTEMPTED;
+	int mldsa_pure_mode = false;
 
 	params.print_container = true;
 
@@ -1458,7 +1471,8 @@ int main(int argc, char* argv[])
 			die(EX_DATAERR, "%s", "Failed to parse container");
 
 		if ((c_v3.ph->ver_alg.hash_alg == HASH_ALG_SHA512 &&
-		     c_v3.ph->ver_alg.sig_alg  != SIG_ALG_SHA512_ECDSA_MLDSA) ||
+		     c_v3.ph->ver_alg.sig_alg  != SIG_ALG_SHA512_ECDSA_MLDSA &&
+		     c_v3.ph->ver_alg.sig_alg  != SIG_ALG_SHA512_ECDSA_MLDSA_PURE_MODE) ||
 		    (c_v3.ph->ver_alg.hash_alg == HASH_ALG_SHA3_512 &&
                      c_v3.ph->ver_alg.sig_alg  != SIG_ALG_SHA3_512_ECDSA_MLDSA))
 			die(EX_DATAERR,
@@ -1466,11 +1480,14 @@ int main(int argc, char* argv[])
 			    "hash_alg '%u' and sig_alg '%u'\n",
 			    c_v3.ph->ver_alg.hash_alg, c_v3.ph->ver_alg.sig_alg);
 
+		mldsa_pure_mode = (c_v3.ph->ver_alg.sig_alg == SIG_ALG_SHA512_ECDSA_MLDSA_PURE_MODE);
+
 		if (params.print_container)
 			display_container_v3(c_v3, c_v3.ph->ver_alg.hash_alg);
 
 		if (params.validate)
-			validate_status = validate_container_v3(c_v3, fdin, c_v3.ph->ver_alg.hash_alg);
+			validate_status = validate_container_v3(c_v3, fdin, c_v3.ph->ver_alg.hash_alg,
+			                                        mldsa_pure_mode);
 
 		if (params.verify)
 			verify_status = verify_container_v3(c_v3, params.verify,

--- a/print-container.c
+++ b/print-container.c
@@ -788,7 +788,7 @@ static bool validate_container_v3(struct parsed_stb_container_v3 c, int fdin, ui
 	if (memcmp(&(c.c->hw_pkey_d), &ECDSA_KEY_NULL, sizeof(ecc_key_t))) {
 		if (mldsa_pure_mode)
 			status = verify_mldsa_87_signature("HW_key_D",
-							   c.ph, sizeof(ROM_prefix_header_v3_raw),
+							   (const unsigned char *)c.ph, sizeof(ROM_prefix_header_v3_raw),
 							   c.pd->hw_sig_d, c.c->hw_pkey_d) && status;
 		else
 			status = verify_mldsa_87_signature("HW_key_D", md, SHA512_DIGEST_LENGTH,
@@ -816,7 +816,7 @@ static bool validate_container_v3(struct parsed_stb_container_v3 c, int fdin, ui
 	if (memcmp(&(c.pd->sw_pkey_s), &ECDSA_KEY_NULL, sizeof(ecc_key_t))) {
 		if (mldsa_pure_mode)
 			status = verify_mldsa_87_signature("SW_key_S",
-							   c.sh, sizeof(ROM_sw_header_v3_raw),
+							   (const unsigned char *)c.sh, sizeof(ROM_sw_header_v3_raw),
 							   c.ssig->sw_sig_s, c.pd->sw_pkey_s) && status;
 		else
 			status = verify_mldsa_87_signature("SW_key_S", md, SHA512_DIGEST_LENGTH,


### PR DESCRIPTION
This PR extends the secure boot tools to enable proper ML-DSA pure mode signing where the raw data are to be passed to the ML-DSA signing function rather than a digest. The tools are extended with a `--pure` option (which means 'sign the raw data') to support it while the old behavior is maintained when this option is not passed. This mode is currently only support when SHA512 is chosen for hashing.
